### PR TITLE
fix(auth): restrict credential file permissions to owner-only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 ENV MCP_CONFIG_DIR=/home/node/.gmail-mcp
 
-# Create logging directory with proper ownership
+# Create config directory for OAuth credentials
 RUN mkdir -p /home/node/.gmail-mcp && \
     chown -R node:node /home/node/.gmail-mcp && \
     chmod -R 755 /home/node/.gmail-mcp

--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -4,11 +4,25 @@ import fs from "fs"
 import http from "http"
 import open from "open"
 
+/**
+ * Writes credential data to a file with owner-only permissions (0o600).
+ * Uses three complementary mechanisms for defense in depth:
+ * 1. umask(0o077) - prevents group/other access at the process level
+ * 2. mode: 0o600 on writeFileSync - requests owner-only permissions from the OS
+ * 3. chmodSync(0o600) - explicitly sets permissions after write as a backstop
+ * If chmod fails after a successful write, the file is deleted to prevent
+ * credentials from sitting on disk with incorrect permissions.
+ */
 const writeCredentialsFile = (filePath: string, data: string) => {
   const oldUmask = process.umask(0o077)
   try {
     fs.writeFileSync(filePath, data, { mode: 0o600 })
-    fs.chmodSync(filePath, 0o600)
+    try {
+      fs.chmodSync(filePath, 0o600)
+    } catch (chmodError: any) {
+      try { fs.unlinkSync(filePath) } catch {}
+      throw new Error(`Failed to set secure permissions on ${filePath}: ${chmodError.message}. File has been removed to prevent insecure credential storage.`)
+    }
   } finally {
     process.umask(oldUmask)
   }
@@ -97,7 +111,17 @@ export const launchAuthServer = async (oauth2Client: OAuth2Client) => new Promis
     try {
       const { tokens } = await oauth2Client.getToken(code)
       oauth2Client.setCredentials(tokens)
-      writeCredentialsFile(GMAIL_CREDENTIALS_PATH, JSON.stringify(tokens, null, 2))
+
+      try {
+        writeCredentialsFile(GMAIL_CREDENTIALS_PATH, JSON.stringify(tokens, null, 2))
+      } catch (writeError: any) {
+        console.error(`Warning: Failed to save credentials to ${GMAIL_CREDENTIALS_PATH}: ${writeError.message}`)
+        res.writeHead(200)
+        res.end(`Authentication succeeded, but credentials could not be saved to ${GMAIL_CREDENTIALS_PATH}: ${writeError.message}. Please check file permissions and try again.`)
+        server.close()
+        resolve(void 0)
+        return
+      }
 
       res.writeHead(200)
       res.end(`Authentication successful! Go to ${GMAIL_CREDENTIALS_PATH} to view your REFRESH_TOKEN. You can close this window.`)
@@ -126,9 +150,14 @@ export const validateCredentials = async (oauth2Client: OAuth2Client) => {
     const { credentials: tokens } = await oauth2Client.refreshAccessToken()
     oauth2Client.setCredentials(tokens)
 
-    writeCredentialsFile(GMAIL_CREDENTIALS_PATH, JSON.stringify(tokens, null, 2))
+    try {
+      writeCredentialsFile(GMAIL_CREDENTIALS_PATH, JSON.stringify(tokens, null, 2))
+    } catch (writeError: any) {
+      console.error(`Warning: Failed to save refreshed credentials to ${GMAIL_CREDENTIALS_PATH}: ${writeError.message}. Credentials are valid in memory but will need to be refreshed again next session.`)
+    }
+
     return true
-  } catch (error: any) { 
+  } catch (error: any) {
     return false
   }
 }

--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -4,6 +4,16 @@ import fs from "fs"
 import http from "http"
 import open from "open"
 
+const writeCredentialsFile = (filePath: string, data: string) => {
+  const oldUmask = process.umask(0o077)
+  try {
+    fs.writeFileSync(filePath, data, { mode: 0o600 })
+    fs.chmodSync(filePath, 0o600)
+  } finally {
+    process.umask(oldUmask)
+  }
+}
+
 const AUTH_SCOPES = [
   'https://www.googleapis.com/auth/gmail.modify',
   'https://www.googleapis.com/auth/gmail.compose',
@@ -87,7 +97,7 @@ export const launchAuthServer = async (oauth2Client: OAuth2Client) => new Promis
     try {
       const { tokens } = await oauth2Client.getToken(code)
       oauth2Client.setCredentials(tokens)
-      fs.writeFileSync(GMAIL_CREDENTIALS_PATH, JSON.stringify(tokens, null, 2))
+      writeCredentialsFile(GMAIL_CREDENTIALS_PATH, JSON.stringify(tokens, null, 2))
 
       res.writeHead(200)
       res.end(`Authentication successful! Go to ${GMAIL_CREDENTIALS_PATH} to view your REFRESH_TOKEN. You can close this window.`)
@@ -116,7 +126,7 @@ export const validateCredentials = async (oauth2Client: OAuth2Client) => {
     const { credentials: tokens } = await oauth2Client.refreshAccessToken()
     oauth2Client.setCredentials(tokens)
 
-    fs.writeFileSync(GMAIL_CREDENTIALS_PATH, JSON.stringify(tokens, null, 2))
+    writeCredentialsFile(GMAIL_CREDENTIALS_PATH, JSON.stringify(tokens, null, 2))
     return true
   } catch (error: any) { 
     return false


### PR DESCRIPTION
## Summary

- OAuth tokens in `credentials.json` were written with default permissions (`0o644`), readable by any local user on the machine
- Adds a `writeCredentialsFile` helper with three layers of protection: `umask(0o077)`, `mode: 0o600`, and `chmodSync` — ensuring credentials are never exposed, even momentarily
- Fixes both write sites: `launchAuthServer()` and `validateCredentials()`
- Separates file-write errors from authentication errors so users get accurate diagnostics instead of misleading "re-authenticate" messages when the real problem is a filesystem issue
- Handles `chmodSync` partial failure by removing insecurely-permissioned files
- Fixes misleading Dockerfile comment ("logging directory" → "config directory for OAuth credentials")

Closes #1

## Test plan

- [ ] `npm run build` compiles without errors
- [ ] Delete `~/.gmail-mcp/credentials.json`, run `npm run auth`, complete OAuth flow, verify `ls -la ~/.gmail-mcp/credentials.json` shows `-rw-------` (0o600)
- [ ] Run `npm test` with OAuth env vars — no regressions
- [ ] Verify that if credential file write fails (e.g. read-only dir), `validateCredentials` still returns true and logs a warning
- [ ] Verify that if credential file write fails during auth flow, browser shows accurate "succeeded but could not be saved" message

🤖 Generated with [Claude Code](https://claude.ai/claude-code)